### PR TITLE
fix(anonymization): redact URLs with placeholder instead of hardcoded link

### DIFF
--- a/src/lib/anonymization.ts
+++ b/src/lib/anonymization.ts
@@ -151,7 +151,7 @@ export const enhancedSanitizeContent = (content: string): string => {
   // Remove URLs that might contain identifying information
   sanitized = sanitized.replace(
     /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/g,
-    'https://www.imdb.com/title/tt3042542/'
+    '[URL REMOVED]'
   );
   
   // Remove specific academic terms that could identify the time period


### PR DESCRIPTION
## Summary

`enhancedSanitizeContent` in `src/lib/anonymization.ts` was replacing every URL it found in user-submitted review content with a hardcoded IMDb link (`https://www.imdb.com/title/tt3042542/` — Big Hero 6). This appears to be leftover test/joke code.

Every other PII pattern in the same function uses a `[X REMOVED]` placeholder (`[EMAIL REMOVED]`, `[PHONE REMOVED]`, `[NAME REMOVED]`, etc.). This PR makes the URL pattern follow the same convention by emitting `[URL REMOVED]`.

## Why this matters

- The previous behaviour rewrote user content into an unrelated third-party link, which is misleading to readers of reviews.
- It contradicts the stated intent of the function — "strips personally identifiable information" — by injecting *a* URL where one was supposed to be removed.

## Change

One-line replacement of the regex's replacement string. No regex / behaviour-of-detection changes.

```diff
-    'https://www.imdb.com/title/tt3042542/'
+    '[URL REMOVED]'
```

## Testing

- TypeScript: `npx tsc --noEmit` — no new errors.
- The function is otherwise unchanged; existing call sites continue to receive a string with all detected URLs redacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined URL anonymization to consistently replace all detected URL-like patterns with a standardized redaction placeholder, ensuring more reliable content sanitization and reducing the risk of inadvertent disclosure of specific URL references throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->