### PR TITLE
chore(supabase): remove debug session logging from browser client

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -12,13 +12,6 @@ const supabase = createBrowserClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 );
 
-// DEBUG: Check auth session at module load
-supabase.auth.getSession().then(res => {
-  console.log("📦 [supabase.ts] Initial session:", res);
-}).catch(err => {
-  console.error("❌ [supabase.ts] Session fetch error:", err);
-});
-
 export { supabase };
 // export const supabase = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
 


### PR DESCRIPTION
## Summary

`src/lib/supabase.ts` ran a debug `console.log` of `supabase.auth.getSession()` at module load. Every page that imports the browser Supabase client would print the user's session — including `access_token` (JWT) and `refresh_token` — to the browser console.

The block was annotated `// DEBUG:` and is clearly leftover instrumentation. This PR removes it.

## Why this matters

Auth tokens in the browser console are visible to:

- shoulder-surfing / screen-recording / screen-sharing
- malicious or buggy browser extensions that read console output
- users who paste console output into bug reports
- third-party analytics tools that scrape console logs

An attacker with the access token can impersonate the user for ~1 hour. With the refresh token, indefinitely until logout.

Classification: **CWE-532** (Insertion of Sensitive Information into Log File).

## Change

Removed the 7-line debug block. No functional change — `getSession()` is still called from `useAuth` and `AuthContext` where the result is consumed properly.

```diff
-// DEBUG: Check auth session at module load
-supabase.auth.getSession().then(res => {
-  console.log("📦 [supabase.ts] Initial session:", res);
-}).catch(err => {
-  console.error("❌ [supabase.ts] Session fetch error:", err);
-});
-
```

## Testing

- `npx tsc --noEmit` — no new errors.
- The file's only export (`supabase`) is unchanged. All consumers continue to work.