### PR TITLE
fix(privacy): sanitize review comments before DB write

### DIFF
--- a/src/components/courses/AddReviewButton.tsx
+++ b/src/components/courses/AddReviewButton.tsx
@@ -14,6 +14,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { supabase } from "@/lib/supabase";
+import { enhancedSanitizeContent } from "@/lib/anonymization";
 import toast from "react-hot-toast";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -76,7 +77,7 @@ export default function AddReviewButton({ courseId }: AddReviewButtonProps) {
         const { error: updateError } = await supabase
           .from("reviews")
           .update({
-            comment: review.comment || null,
+            comment: review.comment ? enhancedSanitizeContent(review.comment) : null,
             updated_at: new Date().toISOString(),
           })
           .eq("id", existingReview.id);

--- a/src/components/professors/AddReviewButtonProfessor.tsx
+++ b/src/components/professors/AddReviewButtonProfessor.tsx
@@ -14,6 +14,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { supabase } from "@/lib/supabase";
+import { enhancedSanitizeContent } from "@/lib/anonymization";
 import toast from "react-hot-toast";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -81,7 +82,7 @@ export default function AddReviewButtonProfessor({
       const { error: updateError } = await supabase
         .from("reviews")
         .update({
-          comment: review.comment || null,
+          comment: review.comment ? enhancedSanitizeContent(review.comment) : null,
           updated_at: new Date().toISOString(),
         })
         .eq("id", existingReview.id);


### PR DESCRIPTION
## Problem

`AddReviewButton` and `AddReviewButtonProfessor` write user-submitted comments directly to the `reviews` table without sanitization. If a student types their email, phone number, name, or student ID into a review, that PII is stored verbatim — defeating the anonymization design.

`enhancedSanitizeContent` already exists in `src/lib/anonymization.ts` and handles all these cases, but it was never called on the write path.

## Fix

Import and call `enhancedSanitizeContent(comment)` before the Supabase `.update()` in both components.

## Files changed (2)

- `src/components/courses/AddReviewButton.tsx`
- `src/components/professors/AddReviewButtonProfessor.tsx`

## Verified

- `tsc --noEmit` clean
- No other files touched