### PR TITLE
security: prevent open redirect in /auth/confirm

### DIFF
--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -6,7 +6,8 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const token_hash = searchParams.get('token_hash')
   const type = searchParams.get('type') as EmailOtpType | null
-  const next = searchParams.get('next') ?? '/auth/callback'
+  const rawNext = searchParams.get('next') ?? '/auth/callback'
+  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/auth/callback'
 
   if (token_hash && type) {
     const supabase = await createClient()


### PR DESCRIPTION
## Vulnerability

The `/auth/confirm` route accepts a `next` query parameter and redirects to it after OTP verification succeeds:

```ts
const next = searchParams.get('next') ?? '/auth/callback'
return NextResponse.redirect(new URL(next, request.url))
```

An attacker can craft a magic-link confirmation URL like:
```
/auth/confirm?token_hash=...&type=email&next=https://evil.com
```

After the user clicks and their OTP verifies, they are redirected to the attacker's site. This enables phishing (fake login page to harvest credentials) or session theft.

## Fix

Validate that `next` is a relative path:
- Must start with `/`
- Must NOT start with `//` (protocol-relative URL, e.g. `//evil.com`)
- Falls back to `/auth/callback` if invalid

## File changed (1)

`src/app/auth/confirm/route.ts` — 2 insertions, 1 deletion