### PR TITLE
security(rls): restrict courses/professors UPDATE to admin

### DIFF
--- a/src/migrations/migration.sql
+++ b/src/migrations/migration.sql
@@ -393,7 +393,7 @@ CREATE POLICY course_insert ON courses
   FOR INSERT WITH CHECK (is_admin());
 
 CREATE POLICY course_update ON courses 
-  FOR UPDATE USING (true) WITH CHECK (true);
+  FOR UPDATE USING (is_admin()) WITH CHECK (is_admin());
 
 CREATE POLICY course_delete ON courses 
   FOR DELETE USING (is_admin());
@@ -406,7 +406,7 @@ CREATE POLICY professor_insert ON professors
   FOR INSERT WITH CHECK (is_admin());
 
 CREATE POLICY professor_update ON professors 
-  FOR UPDATE USING (true) WITH CHECK (true);
+  FOR UPDATE USING (is_admin()) WITH CHECK (is_admin());
 
 CREATE POLICY professor_delete ON professors 
   FOR DELETE USING (is_admin());


### PR DESCRIPTION
## Vulnerability

The RLS UPDATE policies on `courses` and `professors` tables are:

```sql
CREATE POLICY course_update ON courses
  FOR UPDATE USING (true) WITH CHECK (true);

CREATE POLICY professor_update ON professors
  FOR UPDATE USING (true) WITH CHECK (true);
```

This means **any authenticated user** can update any course or professor record — change names, ratings, departments, emails, etc. The original comment says 'allow trigger updates', but triggers defined with `SECURITY DEFINER` bypass RLS entirely, so this permissive policy only benefits attackers.

## Impact

A malicious user with a valid session could:
- Modify course/professor ratings directly in the DB
- Change professor email addresses or names
- Corrupt department or credit data

## Fix

Restrict UPDATE to `is_admin()`, matching the existing INSERT and DELETE policies:

```sql
CREATE POLICY course_update ON courses
  FOR UPDATE USING (is_admin()) WITH CHECK (is_admin());

CREATE POLICY professor_update ON professors
  FOR UPDATE USING (is_admin()) WITH CHECK (is_admin());
```

## Important

This fixes the **migration file**. If the database is already deployed, you also need to run this against the live DB:

```sql
DROP POLICY course_update ON courses;
CREATE POLICY course_update ON courses FOR UPDATE USING (is_admin()) WITH CHECK (is_admin());

DROP POLICY professor_update ON professors;
CREATE POLICY professor_update ON professors FOR UPDATE USING (is_admin()) WITH CHECK (is_admin());
```

## File changed (1)

`src/migrations/migration.sql` — 2 lines changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restricted update permissions for courses and professors. Only administrators can now modify these entities to prevent unauthorized changes to critical data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->