### PR TITLE
fix(seed): require service role key, remove silent fallback

### DIFF
--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -4,7 +4,11 @@ import professorsData from './data/professors.json';
 import coursesData from './data/courses.json';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set to run seed');
+}
 
 const supabase = createClient(supabaseUrl, supabaseServiceKey);
 


### PR DESCRIPTION
## Problem

`seed.ts` line 7:
```ts
const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
```

If `SUPABASE_SERVICE_ROLE_KEY` is unset, the script silently uses the anon key. With RLS policies restricting INSERT/UPDATE on `courses` and `professors` to admin, seeding with the anon key fails with confusing permission errors.

## Fix

Throw immediately with a clear error message if the key is missing.

## File changed (1)

`src/lib/seed.ts` — 4 lines changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization reliability by enforcing required configuration at startup. The system now fails immediately with a clear error message when necessary credentials are missing, preventing silent failures with incorrect authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->